### PR TITLE
Implement C-stage movie generation engine

### DIFF
--- a/src/engine/core/__init__.py
+++ b/src/engine/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core engine exports for YAIBA visualization."""
+from .movie import MovieGenerator
+from . import naming, validation, logging_util
+
+__all__ = ["MovieGenerator", "naming", "validation", "logging_util"]

--- a/src/engine/core/logging_util.py
+++ b/src/engine/core/logging_util.py
@@ -1,0 +1,47 @@
+"""Logging helpers for visualization pipelines."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Mapping
+
+from . import naming
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def get_logger(run_id: str) -> logging.Logger:
+    """Configure a logger that emits to stdout and to a file."""
+
+    logger_name = f"yaiba.movie.{run_id}"
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    if logger.handlers:
+        return logger
+
+    log_path = naming.META_ROOT / "logs" / f"run_{run_id}.log"
+    _ensure_parent(log_path)
+
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    return logger
+
+
+def log_summary(logger: logging.Logger, stats: Mapping[str, object]) -> None:
+    """Emit a formatted summary to *logger*."""
+
+    logger.info("=== 処理サマリー ===")
+    for key, value in stats.items():
+        logger.info("%s: %s", key, value)

--- a/src/engine/core/movie.py
+++ b/src/engine/core/movie.py
@@ -1,0 +1,316 @@
+"""Movie generation for YAIBA trajectories."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+from matplotlib import cm
+from matplotlib import animation
+from zoneinfo import ZoneInfo
+
+from . import logging_util, naming, validation
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+@dataclass
+class MovieParams:
+    duration_real: int = 10800
+    format: str = "mp4"
+    fps: int = 30
+    duration_sec: int = 60
+    bitrate: str = "2M"
+    version: str = "c1.0"
+    min_unique_seconds: int = 180
+
+
+@dataclass
+class PointParams:
+    radius_px: int = 6
+    alpha: float = 1.0
+
+
+@dataclass
+class TrailParams:
+    length_real_seconds: int = 30
+    alpha_start: float = 1.0
+    alpha_end: float = 0.1
+
+
+@dataclass
+class ThemeParams:
+    palette: str = "tab10"
+    bg_color: str = "#eeeeee"
+    font: str = "Meiryo"
+    font_size: int = 16
+
+
+@dataclass
+class IOParams:
+    output_filename: str = "movie"
+    overwrite: bool = False
+
+
+class MovieGenerator:
+    """Generate x–z plane trajectory animations from YAIBA data."""
+
+    def __init__(
+        self,
+        boundary: dict | None = None,
+        outlier: dict | None = None,
+        theme: dict | None = None,
+        movie: dict | None = None,
+        point: dict | None = None,
+        trail: dict | None = None,
+        io: dict | None = None,
+    ) -> None:
+        self.boundary = boundary or {}
+        self.outlier = outlier or {}
+        self.theme = self._merge_params(ThemeParams(), theme)
+        self.movie = self._merge_params(MovieParams(), movie)
+        self.point = self._merge_params(PointParams(), point)
+        self.trail = self._merge_params(TrailParams(), trail)
+        self.io = self._merge_params(IOParams(), io)
+        self._prepare_stats: dict[str, Any] = {}
+
+    @staticmethod
+    def _merge_params(defaults: Any, updates: dict | None) -> dict:
+        data = defaults.__dict__ if hasattr(defaults, "__dict__") else dict(defaults)
+        merged = dict(data)
+        if updates:
+            merged.update(updates)
+        return merged
+
+    def prepare(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Validate and clean the raw intermediate dataframe."""
+
+        validation.require_columns(df, validation.REQUIRED_COLUMNS)
+
+        work = df.copy()
+        work = work.sort_values(["second", "user_id"])
+        work = work.drop_duplicates(subset=["second", "user_id"], keep="last")
+
+        cleaned, dropped = validation.drop_invalid_types(work)
+        cleaned = cleaned.sort_values(["second", "user_id"])
+
+        event_days = cleaned["event_day"].dropna().unique()
+        if len(event_days) > 1:
+            raise ValueError("event_dayは単一である必要があります")
+
+        if not cleaned.empty:
+            start_time = cleaned["second"].min()
+            duration_real = int(self.movie["duration_real"])
+            cutoff = start_time + pd.Timedelta(seconds=duration_real)
+            cleaned = cleaned[cleaned["second"] <= cutoff]
+
+        cleaned = validation.clip_by_boundary(cleaned, self.boundary)
+
+        validation.enforce_min_seconds(
+            cleaned,
+            int(self.movie.get("min_unique_seconds", MovieParams.min_unique_seconds)),
+        )
+
+        cleaned = cleaned.assign(
+            second_jst=cleaned["second"].dt.tz_convert(JST)
+        )
+
+        self._prepare_stats = {
+            "input_rows": len(df),
+            "dropped_invalid_rows": dropped,
+            "output_rows": len(cleaned),
+            "unique_users": int(cleaned["user_id"].nunique()),
+            "unique_seconds": int(cleaned["second"].dt.floor("s").nunique()),
+        }
+        return cleaned
+
+    def _build_user_colors(self, df: pd.DataFrame) -> dict[Any, tuple[float, float, float, float]]:
+        cmap = cm.get_cmap(self.theme["palette"])
+        users = sorted(df["user_id"].unique())
+        if not users:
+            return {}
+        colors: dict[Any, tuple[float, float, float, float]] = {}
+        denom = max(len(users) - 1, 1)
+        for idx, user in enumerate(users):
+            rgba = cmap(idx / denom)
+            colors[user] = (rgba[0], rgba[1], rgba[2], self.point["alpha"])
+        return colors
+
+    def _calc_limits(self, df: pd.DataFrame) -> tuple[float, float, float, float]:
+        x_min = self.boundary.get("location_x_min", float(df["location_x"].min()))
+        x_max = self.boundary.get("location_x_max", float(df["location_x"].max()))
+        z_min = self.boundary.get("location_z_min", float(df["location_z"].min()))
+        z_max = self.boundary.get("location_z_max", float(df["location_z"].max()))
+        if x_min == x_max:
+            x_min -= 1.0
+            x_max += 1.0
+        if z_min == z_max:
+            z_min -= 1.0
+            z_max += 1.0
+        return x_min, x_max, z_min, z_max
+
+    def render(self, df: pd.DataFrame) -> animation.FuncAnimation:
+        """Create the matplotlib animation object."""
+
+        fps = int(self.movie["fps"])
+        duration_sec = int(self.movie["duration_sec"])
+        num_frames = fps * duration_sec
+        if num_frames <= 0:
+            raise ValueError("duration_sec と fps は正の値である必要があります")
+
+        user_colors = self._build_user_colors(df)
+        x_min, x_max, z_min, z_max = self._calc_limits(df)
+
+        plt.rcParams["font.family"] = self.theme["font"]
+        fig, ax = plt.subplots(figsize=(9.6, 7.2), dpi=100)
+        ax.set_facecolor(self.theme["bg_color"])
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylim(z_min, z_max)
+        ax.set_xlabel("X [m]")
+        ax.set_ylabel("Z [m]")
+        title = ax.set_title("YAIBA: ユーザー位置 2Dプロット", fontsize=self.theme["font_size"])
+        time_text = ax.text(
+            0.02,
+            0.95,
+            "",
+            transform=ax.transAxes,
+            ha="left",
+            va="top",
+            fontsize=self.theme["font_size"],
+        )
+
+        base_size = (self.point["radius_px"] * (72 / fig.dpi)) ** 2
+
+        df_sorted = df.sort_values("second")
+        seconds_index = pd.DatetimeIndex(df_sorted["second"].drop_duplicates())
+        start_time = seconds_index[0]
+        if len(seconds_index) > 1:
+            real_span = (seconds_index[-1] - seconds_index[0]).total_seconds()
+        else:
+            real_span = 1.0
+        time_step = real_span / max(num_frames - 1, 1)
+
+        trail_length = float(self.trail["length_real_seconds"])
+        alpha_start = float(self.trail["alpha_start"])
+        alpha_end = float(self.trail["alpha_end"])
+
+        scatter = ax.scatter([], [], s=[], c=[])
+
+        def frame_time(i: int) -> pd.Timestamp:
+            return start_time + pd.to_timedelta(i * time_step, unit="s")
+
+        def update(frame_index: int):
+            current_time = frame_time(frame_index)
+            trail_start = current_time - pd.Timedelta(seconds=trail_length)
+            mask = (df_sorted["second"] >= trail_start) & (df_sorted["second"] <= current_time)
+            frame_df = df_sorted.loc[mask]
+
+            if frame_df.empty:
+                scatter.set_offsets(np.empty((0, 2)))
+                scatter.set_sizes([])
+                scatter.set_facecolors([])
+            else:
+                seconds_ago = (current_time - frame_df["second"]).dt.total_seconds().to_numpy()
+                alphas = np.interp(
+                    seconds_ago,
+                    (0.0, trail_length if trail_length > 0 else 1.0),
+                    (alpha_start, alpha_end),
+                    left=alpha_start,
+                    right=alpha_end,
+                )
+                offsets = frame_df[["location_x", "location_z"]].to_numpy()
+                colors = []
+                for uid, alpha in zip(frame_df["user_id"], alphas):
+                    base = user_colors.get(uid, (0.2, 0.2, 0.2, self.point["alpha"]))
+                    colors.append((base[0], base[1], base[2], float(alpha)))
+                scatter.set_offsets(offsets)
+                scatter.set_sizes(np.full(len(frame_df), base_size))
+                scatter.set_facecolors(colors)
+                scatter.set_edgecolors(colors)
+
+            current_jst = current_time.tz_convert(JST)
+            time_text.set_text(current_jst.strftime("%Y-%m-%d %H:%M:%S JST"))
+            return scatter, time_text
+
+        anim = animation.FuncAnimation(
+            fig,
+            update,
+            frames=num_frames,
+            interval=1000 / fps,
+            blit=False,
+            repeat=False,
+        )
+        return anim
+
+    def save_mp4(self, anim: animation.FuncAnimation, path: str | Path) -> str:
+        """Save the animation as an MP4 file."""
+
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        writer = animation.FFMpegWriter(fps=self.movie["fps"], bitrate=self.movie["bitrate"])
+        anim.save(output_path, writer=writer)
+        plt.close(anim._fig)
+        return str(output_path)
+
+    def run(self, df: pd.DataFrame, output_basename: str | None = None) -> dict[str, str | int]:
+        """Execute the full pipeline."""
+
+        prepared = self.prepare(df)
+        event_day = prepared["event_day"].iloc[0]
+        if isinstance(event_day, pd.Timestamp):
+            event_day_str = event_day.strftime("%Y-%m-%d")
+        else:
+            event_day_str = str(event_day)
+
+        now = datetime.now(tz=JST)
+        dt_str = now.strftime("%Y%m%d_%H%M%S")
+        filename = output_basename or self.io["output_filename"]
+        version = self.movie["version"]
+        basename_core = naming.build_basename(
+            event_day_str,
+            filename,
+            dt_str,
+            version,
+            duration=self.movie["duration_sec"],
+        )
+        movie_filename = f"movie_xz-{basename_core}.{self.movie['format']}"
+        movie_path = naming.result_path("movie", movie_filename)
+        if movie_path.exists() and not self.io.get("overwrite", False):
+            raise FileExistsError(
+                f"既に同名のファイルが存在します: {movie_path}"
+            )
+
+        logger = logging_util.get_logger(dt_str)
+        logger.info("C-2 動画生成を開始します")
+        logger.info("入力行数: %s", self._prepare_stats.get("input_rows"))
+        logger.info("除外行数: %s", self._prepare_stats.get("dropped_invalid_rows"))
+
+        anim = self.render(prepared)
+        frames = int(self.movie["fps"] * self.movie["duration_sec"])
+        logger.info("生成フレーム数: %s", frames)
+
+        output_path = self.save_mp4(anim, movie_path)
+        logger.info("動画を保存しました: %s", output_path)
+
+        logging_util.log_summary(
+            logger,
+            {
+                "mp4_path": output_path,
+                "unique_users": self._prepare_stats.get("unique_users"),
+                "unique_seconds": self._prepare_stats.get("unique_seconds"),
+            },
+        )
+
+        meta = naming.meta_paths(dt_str, version)
+        log_path = meta["log_path"]
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        return {
+            "mp4_path": str(output_path),
+            "log_path": str(log_path),
+            "frames": frames,
+        }

--- a/src/engine/core/naming.py
+++ b/src/engine/core/naming.py
@@ -1,0 +1,52 @@
+"""Naming helpers for YAIBA visualization outputs."""
+from __future__ import annotations
+
+from pathlib import Path
+
+RESULT_ROOT = Path("YAIBA_data") / "output" / "results"
+META_ROOT = Path("YAIBA_data") / "output" / "meta"
+
+_KIND_DIR = {
+    "image": "images",
+    "table": "tables",
+    "movie": "movies",
+}
+
+
+def _sanitize(component: str) -> str:
+    return component.replace(" ", "_")
+
+
+def build_basename(event_day: str, filename: str, dt: str, ver: str, *, duration: int | None = None) -> str:
+    """Build a canonical basename according to the design document."""
+
+    components: list[str] = [
+        _sanitize(event_day),
+        _sanitize(filename),
+        _sanitize(dt),
+    ]
+    if duration is not None:
+        components.append(f"{int(duration)}s")
+    base = "-".join(filter(None, components))
+    return f"{base}_{_sanitize(ver)}"
+
+
+def result_path(kind: str, basename: str) -> Path:
+    """Return the storage path for the given *kind* and *basename*."""
+
+    try:
+        subdir = _KIND_DIR[kind]
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(f"未知の成果物種別です: {kind}") from exc
+    return RESULT_ROOT / subdir / basename
+
+
+def meta_paths(dt: str, ver: str) -> dict[str, Path]:
+    """Return the metadata file paths for the given run."""
+
+    configs = META_ROOT / "configs"
+    logs = META_ROOT / "logs"
+    return {
+        "config_path": configs / f"run_{_sanitize(ver)}_params.yaml",
+        "log_path": logs / f"run_{_sanitize(dt)}.log",
+    }

--- a/src/engine/core/validation.py
+++ b/src/engine/core/validation.py
@@ -1,0 +1,111 @@
+"""Utilities for validating intermediate YAIBA dataframes."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+
+
+REQUIRED_COLUMNS = [
+    "second",
+    "user_id",
+    "location_x",
+    "location_z",
+    "event_day",
+]
+
+
+def require_columns(df: pd.DataFrame, cols: Iterable[str]) -> None:
+    """Ensure all *cols* exist in *df*."""
+
+    missing = [col for col in cols if col not in df.columns]
+    if missing:
+        raise ValueError(
+            "必須列が不足しています: " + ", ".join(sorted(missing))
+        )
+
+
+def _coerce_seconds(series: pd.Series) -> pd.Series:
+    return pd.to_datetime(series, errors="coerce", utc=True)
+
+
+def _coerce_event_day(series: pd.Series) -> pd.Series:
+    days = pd.to_datetime(series, errors="coerce")
+    if hasattr(days.dt, "tz") and days.dt.tz is not None:
+        days = days.dt.tz_convert("Asia/Tokyo").dt.tz_localize(None)
+    return days.dt.normalize()
+
+
+_NUMERIC_COLUMNS = [
+    "location_x",
+    "location_y",
+    "location_z",
+    "rotation_1",
+    "rotation_2",
+    "rotation_3",
+]
+
+
+def drop_invalid_types(df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    """Drop rows that cannot be coerced to the expected dtypes."""
+
+    if df.empty:
+        return df.copy(), 0
+
+    work = df.copy()
+    valid_mask = pd.Series(True, index=work.index)
+    converted: dict[str, pd.Series] = {}
+
+    if "second" in work.columns:
+        seconds = _coerce_seconds(work["second"])
+        converted["second"] = seconds
+        valid_mask &= seconds.notna()
+
+    if "event_day" in work.columns:
+        days = _coerce_event_day(work["event_day"])
+        converted["event_day"] = days
+        valid_mask &= days.notna()
+
+    for col in _NUMERIC_COLUMNS:
+        if col in work.columns:
+            values = pd.to_numeric(work[col], errors="coerce")
+            converted[col] = values
+            valid_mask &= values.notna()
+
+    cleaned = work[valid_mask].copy()
+    for col, series in converted.items():
+        cleaned[col] = series.loc[cleaned.index]
+
+    dropped = int((~valid_mask).sum())
+    return cleaned, dropped
+
+
+def clip_by_boundary(df: pd.DataFrame, boundary: dict) -> pd.DataFrame:
+    """Clip rows outside of the configured spatial boundary."""
+
+    if not boundary:
+        return df.copy()
+
+    work = df.copy()
+    for axis in ("location_x", "location_y", "location_z"):
+        if axis not in work.columns:
+            continue
+        min_key = f"{axis}_min"
+        max_key = f"{axis}_max"
+        lower = boundary.get(min_key)
+        upper = boundary.get(max_key)
+        if lower is not None:
+            work = work[work[axis] >= float(lower)]
+        if upper is not None:
+            work = work[work[axis] <= float(upper)]
+    return work
+
+
+def enforce_min_seconds(df: pd.DataFrame, min_unique_seconds: int) -> None:
+    """Ensure the dataframe has at least *min_unique_seconds* unique timestamps."""
+
+    unique_seconds = df["second"].dt.floor("s").nunique() if not df.empty else 0
+    if unique_seconds < min_unique_seconds:
+        raise ValueError(
+            f"ユニークなsecondが不足しています (必要: {min_unique_seconds}, 実際: {unique_seconds})"
+        )


### PR DESCRIPTION
## Summary
- add validation utilities and naming helpers for YAIBA visualization outputs
- implement MovieGenerator to render trajectory animations and save MP4 results following the design spec
- introduce logging utilities and package exports to support the video pipeline

## Testing
- python -m compileall src
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce9f994888832f8d570446e290463c