### PR TITLE
Develop init fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
     {name = "YAIBA Democratization Project"}
 ]
 dependencies = [
+    "imageio-ffmpeg>=0.6.0",
     "ipykernel>=7.2.0",
     "ipywidgets>=8.1.8",
     "matplotlib>=3.10.8",

--- a/src/yaiba_bi/core/config/__init__.py
+++ b/src/yaiba_bi/core/config/__init__.py
@@ -20,9 +20,9 @@ from .columns import *
 from .errors import *
 from .paths import *
 
-# from .defaults import *
-# from .schemas import *
-# from .layouts import *
+from .defaults import *
+from .schemas import *
+from .layouts import *
 
 
 # init定数用import

--- a/src/yaiba_bi/core/config/__init__.py
+++ b/src/yaiba_bi/core/config/__init__.py
@@ -16,13 +16,14 @@ Attributes:
 """
 
 
-from .columns import *
-from .errors import *
-from .paths import *
-
-from .defaults import *
-from .schemas import *
-from .layouts import *
+from . import (
+    columns,
+    defaults,
+    errors,
+    layouts,
+    paths,
+    schemas
+)
 
 
 # init定数用import

--- a/uv.lock
+++ b/uv.lock
@@ -600,6 +600,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2405,6 +2419,7 @@ name = "yaiba-bi"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "imageio-ffmpeg" },
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "matplotlib" },
@@ -2432,6 +2447,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "imageio-ffmpeg", specifier = ">=0.6.0" },
     { name = "ipykernel", specifier = ">=7.2.0" },
     { name = "ipywidgets", specifier = ">=8.1.8" },
     { name = "matplotlib", specifier = ">=3.10.8" },


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->
実装した定数へのアクセスを有効にし、依存パッケージの内容を更新した


## やったこと
<!-- このPRで何をしたのか？ -->
今回実装した定数へのアクセスを有効にした
uvによるパッケージ管理に移行した際に漏れていたimageio-ffmpegを追記した


## テスト
<!-- テスト方法や確認 -->
- [x] PR前にdevelopブランチからgit pullしましたか？
- [x] テストで動作を担保していますか？

## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
schemas.pyの内容は定数を参照する定数なので、  
念のために既存のyaiba_loader.pyのスキーマ定義と相違ないか確認してます  
結果、問題ありませんでした